### PR TITLE
change libxmljs dep to ~0.13.0 to fix seg fault issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "xml"
   ],
   "dependencies": {
-    "libxmljs": "~0.10.0"
+    "libxmljs": "~0.13.0"
   },
   "devDependencies": {
     "nodeunit": ">=0.9.0"


### PR DESCRIPTION
When using node-plist-native on my Mac (osx 10.10.2) I was encountering some Segmentation Fault errors (including when running the 'npm test' command).  This is resolved by updating the libxmljs dependency from 0.10.0 to 0.13.0