### PR TITLE
Update libxmljs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "xml"
   ],
   "dependencies": {
-    "libxmljs": "^0.17.1"
+    "libxmljs": "^0.18.4"
   },
   "devDependencies": {
     "nodeunit": "0.9.1"


### PR DESCRIPTION
New nodejs versions and old libxmljs don't like each other. Just updating libxmljs makes it work again.